### PR TITLE
First cut at adding tunable PID values

### DIFF
--- a/src/main/java/frc/constants/ArmTunable.java
+++ b/src/main/java/frc/constants/ArmTunable.java
@@ -1,0 +1,36 @@
+package frc.constants;
+
+import edu.wpi.first.wpilibj.Preferences;
+
+public class ArmTunable {
+
+    private static final String namespace = "ArmTunable_";
+
+    private static final String rotatePKey = namespace + "Rotate_P";
+    private static final String rotateIKey = namespace + "Rotate_I";
+    private static final String rotateDKey = namespace + "Rotate_D";
+
+    private static final double rotatePDefault = 0.01;
+    private static final double rotateIDefault = 0.0;
+    private static final double rotateDDefault = 0.0;
+
+    private static double getDoubleValue(String key, double defaultValue) {
+        if(!Preferences.containsKey(key)) {
+            Preferences.setDouble(key, defaultValue);
+        }
+        return Preferences.getDouble(key, defaultValue);
+    }
+
+    public static double getRotateP() {
+        return getDoubleValue(rotatePKey, rotatePDefault);
+    }
+
+    public static double getRotateI() {
+        return getDoubleValue(rotateIKey, rotateIDefault);
+    }
+
+    public static double getRotateD() {
+        return getDoubleValue(rotateDKey, rotateDDefault);
+    }
+
+}

--- a/src/main/java/frc/robot/commands/RotateArmToAngle.java
+++ b/src/main/java/frc/robot/commands/RotateArmToAngle.java
@@ -7,6 +7,7 @@ package frc.robot.commands;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.wpilibj2.command.PIDCommand;
 import frc.robot.subsystems.Arm;
+import frc.constants.ArmTunable;
 
 // NOTE:  Consider using this command inline, rather than writing a subclass.  For more
 // information, see:
@@ -16,7 +17,10 @@ public class RotateArmToAngle extends PIDCommand {
   public RotateArmToAngle(double angle, Arm arm) {
     super(
         // The controller that the command will use
-        new PIDController(.01, 0, 0),
+        new PIDController(
+          ArmTunable.getRotateP(),
+          ArmTunable.getRotateI(),
+          ArmTunable.getRotateD()),
         // This should return the measurement
         () -> arm.getRotationAngle(),
         // This should return the setpoint (can also be a constant)
@@ -34,4 +38,14 @@ public class RotateArmToAngle extends PIDCommand {
   public boolean isFinished() {
     return false;
   }
+
+  @Override
+  public void execute() {
+    PIDController controller = getController();
+    controller.setP(ArmTunable.getRotateP());
+    controller.setI(ArmTunable.getRotateI());
+    controller.setD(ArmTunable.getRotateD());
+    super.execute();
+  }
+    
 }


### PR DESCRIPTION
This change provides the ability to edit PID values in Shuffleboard (RobotPerferences) and have them immediately take effect in the PID controller of the RotateArmToAngle command.