### PR TITLE
Manage burn flash from RobotContainer

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -69,6 +69,7 @@ public class Robot extends TimedRobot {
   /** This autonomous runs the autonomous command selected by your {@link RobotContainer} class. */
   @Override
   public void autonomousInit() {
+    m_robotContainer.autonomousInit();
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
 
     // schedule the autonomous command (example)

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -37,6 +37,7 @@ import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 
 import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
+import edu.wpi.first.wpilibj.DriverStation;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -318,4 +319,16 @@ public class RobotContainer {
   public Command getAutonomousCommand() {
       return m_AutoChooser.getSelected();
   }
+
+  public void autonomousInit() {
+    if (DriverStation.isFMSAttached()) {
+      m_robotDrive.burnFlash();
+      m_claw.burnFlash();
+      // m_arm.burnFlash();
+      m_armProfiled.burnFlash();
+      m_telescope.burnFlash();
+      m_groundIntake.burnFlash();
+    }
+  }
+
 }

--- a/src/main/java/frc/robot/subsystems/ArmPIDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmPIDSubsystem.java
@@ -41,8 +41,6 @@ public class ArmPIDSubsystem extends PIDSubsystem {
 
     m_rotationEncoder.setPositionConversionFactor(ArmConstants.ARM_ROTATION_POSITION_CONVERSION_FACTOR);
     m_rotationFollowerEncoder.setPositionConversionFactor(ArmConstants.ARM_ROTATION_POSITION_CONVERSION_FACTOR);
-    m_rotationLeader.burnFlash(); // Do we need to do this?
-    m_rotationFollower.burnFlash();
 
     // Initial setpoint for starting configuration (stowed, 0.0)
     setSetpoint(ArmConstants.kStowedAngle);
@@ -81,4 +79,9 @@ public class ArmPIDSubsystem extends PIDSubsystem {
     return getMeasurement();
   }
 
+  public void burnFlash() {
+    m_rotationLeader.burnFlash();
+    m_rotationFollower.burnFlash();
+  }
+  
 }

--- a/src/main/java/frc/robot/subsystems/ArmProfiledPIDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmProfiledPIDSubsystem.java
@@ -44,8 +44,6 @@ public class ArmProfiledPIDSubsystem extends ProfiledPIDSubsystem {
     
         m_rotationEncoder.setPositionConversionFactor(ArmConstants.ARM_ROTATION_POSITION_CONVERSION_FACTOR);
         m_rotationFollowerEncoder.setPositionConversionFactor(ArmConstants.ARM_ROTATION_POSITION_CONVERSION_FACTOR);
-        m_rotationLeader.burnFlash(); // Do we need to do this?
-        m_rotationFollower.burnFlash();
 
         setGoal(ArmConstants.kStowedAngle);
 
@@ -103,4 +101,10 @@ public class ArmProfiledPIDSubsystem extends ProfiledPIDSubsystem {
     // Return the process variable measurement here
     return m_rotationEncoder.getPosition();
   }
+
+  public void burnFlash() {
+    m_rotationLeader.burnFlash();
+    m_rotationFollower.burnFlash();
+  }
+
 }

--- a/src/main/java/frc/robot/subsystems/ClawSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClawSubsystem.java
@@ -235,4 +235,9 @@ public class ClawSubsystem extends SubsystemBase {
     // m_nte_IntakeSpeed.setDouble(getIntakeSpeed());
     m_ClawTab.setIntakeCurrent(getIntakeCurrent());
   }
+
+  public void burnFlash() {
+    // only for SparkMax
+  }
+
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -95,11 +95,6 @@ public class DriveSubsystem extends SubsystemBase {
       m_leftEncoderFollower.setVelocityConversionFactor(DriveConstants.VELOCITY_CONVERSION_FACTOR);
       m_rightEncoder.setVelocityConversionFactor(DriveConstants.VELOCITY_CONVERSION_FACTOR);
       m_rightEncoderFollower.setVelocityConversionFactor(DriveConstants.VELOCITY_CONVERSION_FACTOR);
-
-      m_leftMotorLeader.burnFlash();
-      m_leftMotorFollower.burnFlash();
-      m_rightMotorLeader.burnFlash();
-      m_rightMotorFollower.burnFlash();
       
       m_gyro.reset();
       m_gyro.calibrate();
@@ -369,4 +364,10 @@ public class DriveSubsystem extends SubsystemBase {
 //   Trajectory testTrajectory = 
 //     TrajectoryGenerator.generateTrajectory(null, null, null, config)
 //   }
+  public void burnFlash() {
+    m_leftMotorLeader.burnFlash();
+    m_leftMotorFollower.burnFlash();
+    m_rightMotorLeader.burnFlash();
+    m_rightMotorFollower.burnFlash();
+  }
 }

--- a/src/main/java/frc/robot/subsystems/GroundIntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/GroundIntakeSubsystem.java
@@ -71,4 +71,9 @@ public class GroundIntakeSubsystem extends SubsystemBase {
     m_GroundIntakeTab.setIntakeSpeed(getIntakeVelocity());
     m_intakeSetSpeed = m_GroundIntakeTab.getIntakeSetSpeed();
   }
+
+  public void burnFlash() {
+    m_intakeMotor.burnFlash();
+  }
+
 }

--- a/src/main/java/frc/robot/subsystems/TelescopePIDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TelescopePIDSubsystem.java
@@ -28,9 +28,7 @@ public class TelescopePIDSubsystem extends PIDSubsystem {
     m_extensionEncoder = m_extensionMotor.getEncoder();
     m_extensionEncoder.setPosition(ArmConstants.kStowedPosition);
     m_extensionEncoder.setPositionConversionFactor(ArmConstants.ARM_EXTENSION_POSITION_CONVERSION_FACTOR);
-
-    m_extensionMotor.burnFlash();
-    
+ 
     // Initial setpoint for starting configuration (stowed, 0.0)
     setSetpoint(ArmConstants.kStowedPosition);
     
@@ -80,4 +78,9 @@ public class TelescopePIDSubsystem extends PIDSubsystem {
     enable();
     setSetpoint(m_extensionEncoder.getPosition());
   }
+
+  public void burnFlash() {
+    m_extensionMotor.burnFlash();
+  }
+
 }


### PR DESCRIPTION
Centrally manage burn flash for SparkMax motor controllers.
Make it conditional (only burn on FMS attach).