### PR TITLE
Manual mode fixes

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -155,8 +155,8 @@ public class RobotContainer {
     // ManualArmExtendRetract
     m_codriverController.leftStick()
       .onTrue(new ParallelCommandGroup(
-        new InstantCommand(() -> m_armProfiled.manualArmRotate(m_codriverController.getRightX())),
-        new InstantCommand(() -> m_telescope.manualTelescope(m_codriverController.getRightY()))))
+        new RunCommand(() -> m_armProfiled.manualArmRotate(m_codriverController.getLeftX())),
+        new RunCommand(() -> m_telescope.manualTelescope(m_codriverController.getLeftY()))))
       .onFalse(new ParallelCommandGroup(
         new InstantCommand(() -> m_armProfiled.manualDone()),
         new InstantCommand(() -> m_telescope.manualDone())));

--- a/src/main/java/frc/robot/subsystems/ArmProfiledPIDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ArmProfiledPIDSubsystem.java
@@ -88,10 +88,12 @@ public class ArmProfiledPIDSubsystem extends ProfiledPIDSubsystem {
   public void manualArmRotate(double speed){
     double position = getArmRotationDegrees();
     disable();
-    if ((speed > 0.0 && position < ArmConstants.kArmRotateMaxDegrees) ||
-        (speed < 0.0 && position > ArmConstants.kArmRotateMinDegrees)) {
-      m_rotationLeader.set(speed);
-    }
+    if (speed > 0.0 && position < ArmConstants.kArmRotateMaxDegrees) {
+      m_rotationLeader.set(ArmConstants.kArmRotateManualSpeed);
+    } 
+    else if (speed < 0.0 && position > ArmConstants.kArmRotateMinDegrees) {
+      m_rotationLeader.set(-ArmConstants.kArmRotateManualSpeed);
+    } 
     else {
       m_rotationLeader.set(0.0);
     }

--- a/src/main/java/frc/robot/subsystems/TelescopePIDSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/TelescopePIDSubsystem.java
@@ -69,10 +69,12 @@ public class TelescopePIDSubsystem extends PIDSubsystem {
   public void manualTelescope(double speed) {
     double position = getArmExtensionInches();
     disable();
-    if ((speed > 0.0 && position < ArmConstants.kArmExtendMaxInches) ||
-        (speed < 0.0 && position > ArmConstants.kArmExtendMinInches)) {
-      m_extensionMotor.set(speed);
+    if (speed > 0.0 && position < ArmConstants.kArmExtendMaxInches) {
+      m_extensionMotor.set(ArmConstants.kArmExtendManualSpeed);
     }
+    else if (speed < 0.0 && position > ArmConstants.kArmExtendMinInches) {
+      m_extensionMotor.set(-ArmConstants.kArmExtendManualSpeed);
+    } 
     else {
       m_extensionMotor.set(0.0);
     }


### PR DESCRIPTION
Address the following issues when using manual mode:
- Manual mode does not stop when limits are reached 
- Only one axis in manual mode is honored 

**Fix:** instead of `InstantCommand()` use `RunCommand()`

- Manual speed is 100% for arm rotation or telescope

**Fix:** instead of `speed` use `kArmRotateManualSpeed` and `kArmExtendManualSpeed`