### PR TITLE
Start using RobotShare, a prerequisite for new Auto commands

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -59,19 +59,37 @@ import edu.wpi.first.wpilibj.DriverStation;
  * subsystems, commands, and button mappings) should be declared here.
  */
 public class RobotContainer {
+  // New ------------------------------------------------------------------------------------------
   // The robot's subsystems and commands are defined here...
-  private final DriveSubsystem m_robotDrive = new DriveSubsystem();
-  private final LimeLightSubsystem m_limelight = new LimeLightSubsystem();
-  //private final PhotonVisionSubsystem m_photonVision = new PhotonVisionSubsystem();
-  protected final ClawSubsystem m_claw = new ClawSubsystem();
-  // protected final ArmPIDSubsystem m_arm = new ArmPIDSubsystem();
-  protected final ArmProfiledPIDSubsystem m_armProfiled = new ArmProfiledPIDSubsystem();
-  protected final TelescopePIDSubsystem m_telescope = new TelescopePIDSubsystem();
-  protected final GroundIntakeSubsystem m_groundIntake = new GroundIntakeSubsystem();
-  private final SignalLEDSubsystem m_signalLEDs = new SignalLEDSubsystem();
+  private DriveSubsystem m_robotDrive;
+  private LimeLightSubsystem m_limelight;
+  //private PhotonVisionSubsystem m_photonVision;
+  protected ClawSubsystem m_claw;
+  // protected final ArmPIDSubsystem m_arm;
+  protected ArmProfiledPIDSubsystem m_armProfiled;
+  protected TelescopePIDSubsystem m_telescope;
+  protected GroundIntakeSubsystem m_groundIntake;
+  private SignalLEDSubsystem m_signalLEDs;
 
-  private final CommandXboxController m_driverController = new CommandXboxController(OIConstants.kDriverControllerPort);
-  private final CommandXboxController m_codriverController = new CommandXboxController(OIConstants.kCoDriverControllerPort);
+  private CommandXboxController m_driverController;
+  private CommandXboxController m_codriverController;
+
+  private RobotShared m_robotShared;
+  // Old ------------------------------------------------------------------------------------------
+  // // The robot's subsystems and commands are defined here...
+  // private final DriveSubsystem m_robotDrive = new DriveSubsystem();
+  // private final LimeLightSubsystem m_limelight = new LimeLightSubsystem();
+  // //private final PhotonVisionSubsystem m_photonVision = new PhotonVisionSubsystem();
+  // protected final ClawSubsystem m_claw = new ClawSubsystem();
+  // // protected final ArmPIDSubsystem m_arm = new ArmPIDSubsystem();
+  // protected final ArmProfiledPIDSubsystem m_armProfiled = new ArmProfiledPIDSubsystem();
+  // protected final TelescopePIDSubsystem m_telescope = new TelescopePIDSubsystem();
+  // protected final GroundIntakeSubsystem m_groundIntake = new GroundIntakeSubsystem();
+  // private final SignalLEDSubsystem m_signalLEDs = new SignalLEDSubsystem();
+
+  // private final CommandXboxController m_driverController = new CommandXboxController(OIConstants.kDriverControllerPort);
+  // private final CommandXboxController m_codriverController = new CommandXboxController(OIConstants.kCoDriverControllerPort);
+  // ----------------------------------------------------------------------------------------------
   
   SendableChooser<Command> m_AutoChooser = new SendableChooser<>();
 
@@ -120,6 +138,19 @@ public class RobotContainer {
           true));
 
     Shuffleboard.getTab("Autonomous").add(m_AutoChooser);
+    // New ------------------------------------------------------------------------------------------
+    m_robotShared = RobotShared.getInstance();
+
+    m_robotDrive = m_robotShared.getDriveSubsystem();
+    m_limelight = m_robotShared.getLimeLightSubsystem();
+    m_claw = m_robotShared.getClawSubsystem();
+    m_armProfiled = m_robotShared.getArmProfiledPIDSubsystem();
+    m_telescope = m_robotShared.getTelescopePIDSubsystem();
+    m_groundIntake = m_robotShared.getGroundIntakeSubsystem();
+    m_signalLEDs = m_robotShared.getSignalLEDSubsystem();
+    m_driverController = m_robotShared.getDriverController();
+    m_codriverController = m_robotShared.getCodriverController();
+    // ----------------------------------------------------------------------------------------------
 
     m_RobotTab = RobotTab.getInstance();
   }

--- a/src/main/java/frc/robot/commands/Auto_RB_2.java
+++ b/src/main/java/frc/robot/commands/Auto_RB_2.java
@@ -7,6 +7,7 @@ package frc.robot.commands;
 import frc.robot.RobotShared;
 import frc.robot.commands.basic.ClawScore;
 import frc.robot.subsystems.DriveSubsystem;
+
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import edu.wpi.first.math.util.Units;

--- a/src/main/java/frc/robot/commands/Auto_RB_2_Exit_Balance.java
+++ b/src/main/java/frc/robot/commands/Auto_RB_2_Exit_Balance.java
@@ -7,6 +7,7 @@ package frc.robot.commands;
 import frc.robot.RobotShared;
 import frc.robot.commands.basic.ClawScore;
 import frc.robot.subsystems.DriveSubsystem;
+
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import edu.wpi.first.math.util.Units;

--- a/src/main/java/frc/robot/commands/Auto_RB_3.java
+++ b/src/main/java/frc/robot/commands/Auto_RB_3.java
@@ -7,6 +7,7 @@ package frc.robot.commands;
 import frc.robot.RobotShared;
 import frc.robot.commands.basic.ClawScore;
 import frc.robot.subsystems.DriveSubsystem;
+
 import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
 
 import edu.wpi.first.math.util.Units;

--- a/src/main/java/frc/robot/commands/TurnToAngle.java
+++ b/src/main/java/frc/robot/commands/TurnToAngle.java
@@ -43,7 +43,7 @@ public class TurnToAngle extends PIDCommand {
   public boolean isFinished() {
     // End when the controller is at the reference.
     // return getController().atSetpoint();
-    System.out.println("TurnToAngle is deprecated. Use TurnToAngleProfiled!")
+    System.out.println("TurnToAngle is deprecated. Use TurnToAngleProfiled!");
     return true;
   }
 }


### PR DESCRIPTION
This change is necessary to ensure there is only one instance of all the subsystems.

- Eventually all commands will not need subsystems passed in and instead whatever is needed from `RobotShared`
- In the meantime, this hybrid approach allows:
  - `RobotContainer` to pass around subsystems to old-style commands
  - New-style commands can get to the same subsystems by asking `RobotShared` for anything missing