### PR TITLE
Separate gamepiece angles and positions for new commands

### DIFF
--- a/src/main/java/frc/constants/ArmConstants.java
+++ b/src/main/java/frc/constants/ArmConstants.java
@@ -46,6 +46,15 @@ public class ArmConstants {
     public static final float kMaxSoftLimitPosition   = 30;
 
     // New ----------------------------------------------------------------------------------------
+    public enum AutoMode {
+        HIGH,
+        MID,
+        LOW,
+        SHELF,
+        FLOOR,
+        STOWED
+    }    
+
     // Cone
     public static final double kConeHighAngle         = 77;
     public static final double kConeMidAngle          = 75;

--- a/src/main/java/frc/robot/ButtonBindings.java
+++ b/src/main/java/frc/robot/ButtonBindings.java
@@ -369,8 +369,6 @@ public class ButtonBindings {
           new InstantCommand(() -> m_armProfiled.setGoal(ArmConstants.kLowNodeAngle))));
           // new InstantCommand(() -> m_telescope.setSetpoint(ArmConstants.kLowNodePosition)));
   
-      m_codriverController.rightBumper()
-        .onTrue(new InstantCommand(() -> m_claw.toggle()));
     }
   
     private void bind_LedModeTest() {
@@ -388,11 +386,6 @@ public class ButtonBindings {
         .onTrue(new InstantCommand(() -> m_signalLEDs.setMode(LedMode.CONE, LedPreference.MAIN, false)))
         .onFalse(new InstantCommand(() -> m_signalLEDs.setMode(LedMode.OFF, LedPreference.MAIN, false)));
   
-      m_codriverController.x()
-        .toggleOnTrue(new InstantCommand(() -> m_claw.grabOrReleaseCube()));
-  
-      m_codriverController.y()
-        .toggleOnTrue(new InstantCommand(() -> m_claw.grabOrReleaseCone()));
     }
   
     private void bind_LedSubsystemTest() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -515,8 +515,6 @@ public class RobotContainer {
         new InstantCommand(() -> m_armProfiled.setGoal(ArmConstants.kLowNodeAngle))));
         // new InstantCommand(() -> m_telescope.setSetpoint(ArmConstants.kLowNodePosition)));
 
-    m_codriverController.rightBumper()
-      .onTrue(new InstantCommand(() -> m_claw.toggle()));
   }
 
   private void bind_LedModeTest() {
@@ -530,11 +528,6 @@ public class RobotContainer {
       .onTrue(new InstantCommand(() -> m_signalLEDs.setMode(LedMode.CONE, LedPreference.MAIN, false)))
       .onFalse(new InstantCommand(() -> m_signalLEDs.setMode(LedMode.OFF, LedPreference.MAIN, false)));
 
-    m_codriverController.x()
-      .toggleOnTrue(new InstantCommand(() -> m_claw.grabOrReleaseCube()));
-
-    m_codriverController.y()
-      .toggleOnTrue(new InstantCommand(() -> m_claw.grabOrReleaseCone()));
   }
 
   private void bind_LedSubsystemTest() {

--- a/src/main/java/frc/robot/RobotShared.java
+++ b/src/main/java/frc/robot/RobotShared.java
@@ -6,6 +6,7 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import frc.board.RobotTab;
+import frc.constants.ArmConstants;
 import frc.constants.OIConstants;
 import frc.constants.OIConstants.GamePiece;
 import frc.robot.subsystems.ArmProfiledPIDSubsystem;
@@ -88,6 +89,75 @@ public class RobotShared {
 
     public RobotTab getRobotTab() {
         return m_robotTab;
+    }
+
+    // This seems to be the best place- knows about GamePiece and Arm
+    public double calculateTeleSetpoint(ArmConstants.AutoMode mode) {
+        GamePiece piece = m_robotTab.getGamePiece();
+        switch (mode) {
+            case HIGH:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeHighPosition;
+                else
+                    return ArmConstants.kCubeHighPosition;
+            case MID:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeMidPosition;
+                else
+                    return ArmConstants.kCubeMidPosition;
+            case LOW:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeLowPosition;
+                else
+                    return ArmConstants.kCubeLowPosition;
+            case SHELF:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeShelfPosition;
+                else
+                    return ArmConstants.kCubeShelfPosition;
+            case FLOOR:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeFloorPosition;
+                else
+                    return ArmConstants.kCubeFloorPosition;
+            case STOWED:
+            default:
+                return ArmConstants.kStowedPosition;
+        }
+    }
+
+    public double calculateArmSetpoint(ArmConstants.AutoMode mode) {
+        GamePiece piece = m_robotTab.getGamePiece();
+        switch (mode) {
+            case HIGH:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeHighAngle;
+                else
+                    return ArmConstants.kCubeHighAngle;
+            case MID:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeMidAngle;
+                else
+                    return ArmConstants.kCubeMidAngle;
+            case LOW:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeLowAngle;
+                else
+                    return ArmConstants.kCubeLowAngle;
+            case SHELF:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeShelfAngle;
+                else
+                    return ArmConstants.kCubeShelfAngle;
+            case FLOOR:
+                if (piece == OIConstants.GamePiece.CONE)
+                    return ArmConstants.kConeFloorAngle;
+                else
+                    return ArmConstants.kCubeFloorAngle;
+            case STOWED:
+            default:
+                return ArmConstants.kStowedAngle;
+        }
     }
 
     public void toggleGamePiece() {

--- a/src/main/java/frc/robot/commands/DriveToChargeStation.java
+++ b/src/main/java/frc/robot/commands/DriveToChargeStation.java
@@ -27,6 +27,7 @@ public class DriveToChargeStation extends CommandBase {
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
+    //  Consider setting m_initialRoll to 0 in case the command is started when already tilted
     m_initialRoll = m_drive.getRoll();
     m_initialHeading = m_drive.getAngle();
     if (Math.abs(m_initialRoll) > AutoConstants.kRollThresholdDegrees) {

--- a/src/main/java/frc/robot/commands/basic/ArmToSetpoint.java
+++ b/src/main/java/frc/robot/commands/basic/ArmToSetpoint.java
@@ -5,6 +5,7 @@
 package frc.robot.commands.basic;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.constants.ArmConstants.AutoMode;
 import frc.robot.RobotShared;
 import frc.robot.subsystems.ArmProfiledPIDSubsystem;
 
@@ -15,9 +16,9 @@ public class ArmToSetpoint extends CommandBase {
   private Double m_setpoint;
 
   /** Creates a new ArmToSetpoint. */
-  public ArmToSetpoint(Double setpoint) {
-    m_setpoint = setpoint;
+  public ArmToSetpoint(AutoMode mode) {
     m_robotShared = RobotShared.getInstance();
+    m_setpoint = m_robotShared.calculateArmSetpoint(mode);
     m_armProfiled = m_robotShared.getArmProfiledPIDSubsystem();
     addRequirements(m_armProfiled);
   }

--- a/src/main/java/frc/robot/commands/basic/TelescopeToSetpoint.java
+++ b/src/main/java/frc/robot/commands/basic/TelescopeToSetpoint.java
@@ -5,6 +5,7 @@
 package frc.robot.commands.basic;
 
 import edu.wpi.first.wpilibj2.command.CommandBase;
+import frc.constants.ArmConstants.AutoMode;
 import frc.robot.RobotShared;
 import frc.robot.subsystems.TelescopePIDSubsystem;
 
@@ -15,10 +16,11 @@ public class TelescopeToSetpoint extends CommandBase {
   private Double m_setpoint;
 
   /** Creates a new TelescopeToSetpoint. */
-  public TelescopeToSetpoint(Double setpoint) {
-    m_setpoint = setpoint;
+  public TelescopeToSetpoint(AutoMode mode) {
     m_robotShared = RobotShared.getInstance();
+    m_setpoint = m_robotShared.calculateTeleSetpoint(mode);
     m_telescope = m_robotShared.getTelescopePIDSubsystem();
+
     addRequirements(m_telescope);
   }
 

--- a/src/main/java/frc/robot/commands/driver/ArmStow.java
+++ b/src/main/java/frc/robot/commands/driver/ArmStow.java
@@ -15,8 +15,8 @@ public class ArmStow extends SequentialCommandGroup {
   public ArmStow() {
 
     addCommands(
-      new TelescopeToSetpoint(ArmConstants.kStowedPosition),
-      new ArmToSetpoint(ArmConstants.kStowedAngle));
+      new TelescopeToSetpoint(ArmConstants.AutoMode.STOWED),
+      new ArmToSetpoint(ArmConstants.AutoMode.STOWED));
   }
 
 }

--- a/src/main/java/frc/robot/commands/driver/AutoArmRetrieveLow.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmRetrieveLow.java
@@ -18,8 +18,8 @@ public class AutoArmRetrieveLow extends SequentialCommandGroup {
   public AutoArmRetrieveLow() {
 
     addCommands(
-      new ArmToSetpoint(ArmConstants.kLowRetrieveAngle),
-      new TelescopeToSetpoint(ArmConstants.kLowRetrievePosition),
+      new ArmToSetpoint(ArmConstants.AutoMode.FLOOR),
+      new TelescopeToSetpoint(ArmConstants.AutoMode.FLOOR),
       new ClawRetrieve(),
       new ClawWaitOnPiece(),
       new ClawHold());

--- a/src/main/java/frc/robot/commands/driver/AutoArmRetrieveMedium.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmRetrieveMedium.java
@@ -18,8 +18,8 @@ public class AutoArmRetrieveMedium extends SequentialCommandGroup {
   public AutoArmRetrieveMedium() {
 
     addCommands(
-      new ArmToSetpoint(ArmConstants.kMidRetrieveAngle),
-      new TelescopeToSetpoint(ArmConstants.kMidRetrievePosition),
+      new ArmToSetpoint(ArmConstants.AutoMode.SHELF),
+      new TelescopeToSetpoint(ArmConstants.AutoMode.SHELF),
       new ClawRetrieve(),
       new ClawWaitOnPiece(),
       new ClawHold());

--- a/src/main/java/frc/robot/commands/driver/AutoArmScoreHigh.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmScoreHigh.java
@@ -16,8 +16,8 @@ public class AutoArmScoreHigh extends SequentialCommandGroup {
   public AutoArmScoreHigh() {
 
     addCommands(
-      new TelescopeToSetpoint(ArmConstants.kHighNodePosition),
-      new ArmToSetpoint(ArmConstants.kHighNodeAngle),
+      new ArmToSetpoint(ArmConstants.AutoMode.HIGH),
+      new TelescopeToSetpoint(ArmConstants.AutoMode.HIGH),
       new ClawHold());
   }
 

--- a/src/main/java/frc/robot/commands/driver/AutoArmScoreLow.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmScoreLow.java
@@ -16,8 +16,8 @@ public class AutoArmScoreLow extends SequentialCommandGroup {
   public AutoArmScoreLow() {
 
     addCommands(
-      new ArmToSetpoint(ArmConstants.kLowNodeAngle),
-      new TelescopeToSetpoint(ArmConstants.kLowNodePosition),
+      new ArmToSetpoint(ArmConstants.AutoMode.LOW),
+      new TelescopeToSetpoint(ArmConstants.AutoMode.LOW),
       new ClawHold());
   }
 

--- a/src/main/java/frc/robot/commands/driver/AutoArmScoreMedium.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmScoreMedium.java
@@ -16,8 +16,8 @@ public class AutoArmScoreMedium extends SequentialCommandGroup {
   public AutoArmScoreMedium() {
 
     addCommands(
-      new ArmToSetpoint(ArmConstants.kMidNodeAngle),
-      new TelescopeToSetpoint(ArmConstants.kMidNodePosition),
+      new ArmToSetpoint(ArmConstants.AutoMode.MID),
+      new TelescopeToSetpoint(ArmConstants.AutoMode.MID),
       new ClawHold());
   }
 

--- a/src/main/java/frc/robot/subsystems/ClawSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ClawSubsystem.java
@@ -87,48 +87,6 @@ public class ClawSubsystem extends SubsystemBase {
     setMode(ClawMode.READY);
   }
 
-  public void grabCone() {
-    m_intakeMotor.set(ClawConstants.kConeInjectSpeed);
-    close();
-    setMode(ClawMode.CONE);
-  }
-
-  public void dropCone() {
-    m_intakeMotor.set(0.0);
-    open();
-  }
-
-  public void grabOrReleaseCone() {
-    if (getMode() == ClawMode.READY) {
-      grabCone();
-    }
-    else {
-      dropCone();
-    }
-  }
-
-  public void grabOrReleaseCube() {
-    if (getMode() == ClawMode.READY) {
-      intakeCube();
-    }
-    else {
-      ejectCube();
-    }
-  }
-
-  public void toggle() {
-    switch(m_clawMode) {
-      case CUBE: // We're currently set for a cube (or "READY")
-      case READY:
-        close();
-        break;
-      case CONE: // We're currently set for a cone
-        open();
-        default: // Should be no other modes, but do nothing in any case
-        break;
-    }
-  }
-
   public void close() { // Close to grab a cone
     m_grabberSolenoid.set(kReverse); 
     setMode(ClawMode.CONE);


### PR DESCRIPTION
**Changes**
- Fully support different `CUBE`/`CONE` settings for arm and telescope in new-style commands
  - `driver/Arm` commands
  - `driver/AutoArm` commands

- Confusing/stale claw methods used only in test mode
  - Removed method definitions (`toggle` and `grabOrRelease`)
  - Remove callers of the methods in `ButtonBindings` and `RobotContainer.ButtonBindings`
- Move calculation of setpoints for arm and tele to one location: `RobotShared`

**Todo**
Make all command usage new style (replace lambdas in `ButtonBindings` and `RobotContainer.ButtonBindings`)