### PR TITLE
Add Auto Claw_Ready commands; remove deprecated ArmConstants

### DIFF
--- a/src/main/java/frc/constants/ArmConstants.java
+++ b/src/main/java/frc/constants/ArmConstants.java
@@ -45,7 +45,6 @@ public class ArmConstants {
     public static final float kMinSoftLimitPosition   = 0;
     public static final float kMaxSoftLimitPosition   = 30;
 
-    // New ----------------------------------------------------------------------------------------
     public enum AutoMode {
         HIGH,
         MID,
@@ -70,8 +69,8 @@ public class ArmConstants {
 
     // Cube
     public static final double kCubeHighAngle         = 89;
-    public static final double kCubeMidAngle          = 92;
-    public static final double kCubeLowAngle          = 140;
+    public static final double kCubeMidAngle          = 95;
+    public static final double kCubeLowAngle          = 142;
     public static final double kCubeShelfAngle        = 87;
     public static final double kCubeFloorAngle        = 173;
 
@@ -81,34 +80,6 @@ public class ArmConstants {
     public static final double kCubeShelfPosition     = 7.5;
     public static final double kCubeFloorPosition     = 0;
 
-    // Temp- to be removed after further refactoring
-    // public static final double kHighNodeAngle        = kConeHighAngle;
-    // public static final double kMidNodeAngle         = kConeMidAngle;
-    // public static final double kLowNodeAngle         = kConeLowAngle;
-    // public static final double kMidRetrieveAngle     = kConeShelfAngle;
-    // public static final double kLowRetrieveAngle     = kConeFloorAngle;
-    
-    // public static final double kHighNodePosition     = kConeHighPosition;
-    // public static final double kMidNodePosition      = kConeMidPosition;
-    // public static final double kLowNodePosition      = kConeLowPosition; 
-    // public static final double kMidRetrievePosition  = kConeShelfPosition;
-    // public static final double kLowRetrievePosition  = kConeFloorPosition;
-
-    // Old ----------------------------------------------------------------------------------------
-    // public static final double kHighNodeAngle        = 80;  // FIXME: tune angles
-    // public static final double kMidNodeAngle         = 75;
-    // public static final double kLowNodeAngle         = 140;
-    // public static final double kMidRetrieveAngle     = 87;
-    // public static final double kLowRetrieveAngle     = 173;
-    // //Cone hi node 77 angle 28.5
-    // //Cube hi node 80 angle, 27.5
-    
-    // public static final double kHighNodePosition     = 27.5; // FIXME: tune telescope
-    // public static final double kMidNodePosition      = 8.5;
-    // public static final double kLowNodePosition      = 0;  
-    // public static final double kMidRetrievePosition  = 7.5; 
-    // public static final double kLowRetrievePosition  = 0;
-    //---------------------------------------------------------------------------------------------
 
     public static final double rotatePDefault = 0.12149;
     public static final double rotateIDefault = 0.0;

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -21,10 +21,12 @@ import frc.constants.OIConstants;
 import frc.constants.OIConstants.GamePiece;
 import frc.robot.commands.AutoBalancePID;
 import frc.robot.commands.Auto_RB_1;
+import frc.robot.commands.Auto_RB_1_Claw_Ready;
 import frc.robot.commands.Auto_RB_2;
 import frc.robot.commands.Auto_RB_2_Exit_Balance;
 import frc.robot.commands.Auto_RB_2_Pickup;
 import frc.robot.commands.Auto_RB_3;
+import frc.robot.commands.Auto_RB_3_Claw_Ready;
 import frc.robot.commands.DriveToDistance;
 import frc.robot.commands.SubStationSideAuto;
 //import frc.robot.commands.SequentialVisionAlign;
@@ -226,18 +228,24 @@ public class RobotContainer {
       .onTrue(new Auto_RB_2_Exit_Balance());
 
     m_driverController.leftBumper()
-    .  onTrue(new Auto_RB_3());
+      .onTrue(new Auto_RB_3());
+  
+    m_driverController.x()
+      .onTrue(new Auto_RB_1_Claw_Ready());
 
-  }
+    m_driverController.rightStick()
+      .onTrue(new Auto_RB_3_Claw_Ready());
+
+      }
 
   // See the Robot Control documents for the spec
   private void bind_RC_ManualArm() {
     // ManualArmUpDown
-    // ManualArmExtendRetract
     m_codriverController.leftStick()
       .whileTrue(new RunCommand(() -> m_armProfiled.manualArmRotate(m_codriverController.getLeftY())))
       .onFalse(new InstantCommand(() -> m_armProfiled.manualDone()));
 
+    // ManualArmExtendRetract
     m_codriverController.rightStick()
     .whileTrue(new RunCommand(() -> m_telescope.manualTelescope(m_codriverController.getRightY())))
     .onFalse(new InstantCommand(() -> m_telescope.manualDone()));

--- a/src/main/java/frc/robot/commands/Auto_RB_1_Claw_Ready.java
+++ b/src/main/java/frc/robot/commands/Auto_RB_1_Claw_Ready.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import frc.robot.RobotShared;
+import frc.constants.ArmConstants.AutoMode;
+
+import frc.robot.commands.basic.ClawScore;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.ArmProfiledPIDSubsystem;
+import frc.robot.subsystems.TelescopePIDSubsystem;
+
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+
+import edu.wpi.first.math.util.Units;
+
+
+public class Auto_RB_1_Claw_Ready extends SequentialCommandGroup {
+  private DriveSubsystem m_drive;
+  private RobotShared m_robotShared;
+  private ArmProfiledPIDSubsystem m_arm;
+  private TelescopePIDSubsystem m_telescope;
+
+  public Auto_RB_1_Claw_Ready() {
+
+    m_robotShared = RobotShared.getInstance();
+    m_drive = m_robotShared.getDriveSubsystem();
+    m_arm = m_robotShared.getArmProfiledPIDSubsystem();
+    m_telescope = m_robotShared.getTelescopePIDSubsystem();
+
+    addCommands (
+      new ClawScore(),
+      new DriveToDistance(Units.inchesToMeters(-155.875), m_drive),
+      new TurnToAngleProfiled(-166.883, m_drive),
+      new DriveToDistance(Units.inchesToMeters(20.0), m_drive),
+      new InstantCommand(() -> m_telescope.setSetpoint(m_robotShared.calculateTeleSetpoint(AutoMode.FLOOR))),
+      new InstantCommand(() -> m_arm.setGoal(m_robotShared.calculateArmSetpoint(AutoMode.FLOOR))),
+      new WaitUntilCommand(m_arm::atGoal),
+      new WaitUntilCommand(m_telescope::atSetpoint)
+    );
+
+  }
+}

--- a/src/main/java/frc/robot/commands/Auto_RB_3_Claw_Ready.java
+++ b/src/main/java/frc/robot/commands/Auto_RB_3_Claw_Ready.java
@@ -1,0 +1,47 @@
+// Copyright (c) FIRST and other WPILib contributors.
+// Open Source Software; you can modify and/or share it under the terms of
+// the WPILib BSD license file in the root directory of this project.
+
+package frc.robot.commands;
+
+import frc.robot.RobotShared;
+import frc.constants.ArmConstants.AutoMode;
+
+import frc.robot.commands.basic.ClawScore;
+import frc.robot.subsystems.DriveSubsystem;
+import frc.robot.subsystems.ArmProfiledPIDSubsystem;
+import frc.robot.subsystems.TelescopePIDSubsystem;
+
+import edu.wpi.first.wpilibj2.command.SequentialCommandGroup;
+import edu.wpi.first.wpilibj2.command.InstantCommand;
+import edu.wpi.first.wpilibj2.command.WaitUntilCommand;
+
+import edu.wpi.first.math.util.Units;
+
+
+public class Auto_RB_3_Claw_Ready extends SequentialCommandGroup {
+  private DriveSubsystem m_drive;
+  private RobotShared m_robotShared;
+  private ArmProfiledPIDSubsystem m_arm;
+  private TelescopePIDSubsystem m_telescope;
+
+  public Auto_RB_3_Claw_Ready() {
+
+    m_robotShared = RobotShared.getInstance();
+    m_drive = m_robotShared.getDriveSubsystem();
+    m_arm = m_robotShared.getArmProfiledPIDSubsystem();
+    m_telescope = m_robotShared.getTelescopePIDSubsystem();
+
+    addCommands (
+      new ClawScore(),
+      new DriveToDistance(Units.inchesToMeters(-155.875), m_drive),
+      new TurnToAngleProfiled(166.883, m_drive),
+      new DriveToDistance(Units.inchesToMeters(20.0), m_drive),
+      new InstantCommand(() -> m_telescope.setSetpoint(m_robotShared.calculateTeleSetpoint(AutoMode.FLOOR))),
+      new InstantCommand(() -> m_arm.setGoal(m_robotShared.calculateArmSetpoint(AutoMode.FLOOR))),
+      new WaitUntilCommand(m_arm::atGoal),
+      new WaitUntilCommand(m_telescope::atSetpoint)
+    );
+
+  }
+}


### PR DESCRIPTION
Add two commands
- `Auto_RB_1_Claw_Ready()` <- driver X
- `Auto_RB_3_Claw_Ready()` <- driver rightStick (push)

Remove unused Arm Constants (were marked Temp and commented out)

