### PR TITLE
Cleanup new vision commands- signatures, units

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -57,6 +57,9 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
 import edu.wpi.first.wpilibj.DriverStation;
 
+import edu.wpi.first.math.util.Units;
+
+
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
  * "declarative" paradigm, very little robot logic should actually be handled in the {@link Robot}
@@ -369,7 +372,7 @@ public class RobotContainer {
 
   private void bind_DriveToDistanceVision(){
     m_driverController.rightStick()
-    .whileTrue(new DriveToDistanceVision(0.5, false, 0.2 ,m_robotDrive, m_photonVision));
+    .whileTrue(new DriveToDistanceVision(Units.inchesToMeters(-20.0), 0.2, m_robotDrive, m_photonVision));
   }
 
   private void bind_POVTest() {

--- a/src/main/java/frc/robot/commands/DriveToDistanceVision.java
+++ b/src/main/java/frc/robot/commands/DriveToDistanceVision.java
@@ -11,7 +11,7 @@ import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.PhotonVisionSubsystem;
 
 public class DriveToDistanceVision extends CommandBase {
-  /** Creates a new DriveToDistance. */
+  /** Creates a new DriveToDistanceVision. */
   
   private final DriveSubsystem m_drive;
   private final PhotonVisionSubsystem m_vision;
@@ -21,16 +21,15 @@ public class DriveToDistanceVision extends CommandBase {
   private double m_direction;
   private double m_power;
 
-  public DriveToDistanceVision(double meters, Boolean driveForward, double power, DriveSubsystem drive, PhotonVisionSubsystem vision) {
+  public DriveToDistanceVision(double meters, double power, DriveSubsystem drive, PhotonVisionSubsystem vision) {
     m_meters = meters;
-    m_direction = (driveForward) ? 1 : -1;
+    m_direction = Math.signum(meters);
     m_power = power;
     m_drive = drive;
     m_vision = vision;
 
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(m_drive, m_vision);
-
   }
 
   // Called when the command is initially scheduled.
@@ -46,7 +45,6 @@ public class DriveToDistanceVision extends CommandBase {
   @Override
   public void execute() {
     double angleDelta = m_initialHeading - m_drive.getEstimatedVisionPose().getRotation().getDegrees();
-    //double distanceDelta =  m_vision.getDistanceToPose(m_initialPose);
     m_drive.simpleArcadeDrive(m_direction * m_power,
       AutoConstants.kAngleCorrectionP * angleDelta, false);
   }

--- a/src/main/java/frc/robot/commands/DriveTowardsPose.java
+++ b/src/main/java/frc/robot/commands/DriveTowardsPose.java
@@ -11,7 +11,7 @@ import frc.robot.subsystems.DriveSubsystem;
 import frc.robot.subsystems.PhotonVisionSubsystem;
 
 public class DriveTowardsPose extends CommandBase {
-  /** Creates a new DriveToDistance. */
+  /** Creates a new DriveTowardsPose. */
   
   private final DriveSubsystem m_drive;
   private final PhotonVisionSubsystem m_vision;
@@ -21,16 +21,15 @@ public class DriveTowardsPose extends CommandBase {
   private double m_direction;
   private Pose2d m_targetPose;
 
-  public DriveTowardsPose(double meters, Boolean driveForward, double power, Pose2d targetPose, DriveSubsystem drive, PhotonVisionSubsystem vision) {
+  public DriveTowardsPose(double meters, double power, Pose2d targetPose, DriveSubsystem drive, PhotonVisionSubsystem vision) {
     m_meters = meters;
-    m_direction = (driveForward) ? 1 : -1;
+    m_direction = Math.signum(meters);
     m_targetPose = targetPose;
     m_drive = drive;
     m_vision = vision;
 
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(m_drive, m_vision);
-
   }
 
   // Called when the command is initially scheduled.
@@ -38,14 +37,13 @@ public class DriveTowardsPose extends CommandBase {
   public void initialize() {
     m_initialPose = m_drive.getEstimatedVisionPose();
     // Goal = distance to travel + current position
-    
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
   public void execute() {
-    double angleDelta = m_vision.getYawToPose(m_targetPose).getDegrees(); //m_drive.getEstimatedVisionPose().getRotation().getDegrees() - m_initialPose.getRotation().plus(m_vision.getYawToPose(m_targetPose)).getDegrees();
-    //double distanceDelta =  m_vision.getDistanceToPose(m_initialPose);
+    double angleDelta = m_vision.getYawToPose(m_targetPose).getDegrees();
+    //m_drive.getEstimatedVisionPose().getRotation().getDegrees() - m_initialPose.getRotation().plus(m_vision.getYawToPose(m_targetPose)).getDegrees();
     m_drive.simpleArcadeDrive(m_direction * m_power,
       AutoConstants.kAngleCorrectionP * angleDelta, false);
   }

--- a/src/main/java/frc/robot/commands/auto/RB_2_Arm_Pickup.java
+++ b/src/main/java/frc/robot/commands/auto/RB_2_Arm_Pickup.java
@@ -53,19 +53,19 @@ public class RB_2_Arm_Pickup extends SequentialCommandGroup {
       ),
 
       // Drive over the charge station and exit the community
-      new DriveToDistanceVision(3.94, false, 0.3, m_drive, m_photonVision),
+      new DriveToDistanceVision(Units.inchesToMeters(-155.0), 0.3, m_drive, m_photonVision),
 
       new TurnTowardsPose(gamePiecePose, m_drive, m_photonVision),
       // Prepare the arm to pickup a piece and drive to the piece
       new AutoArmRetrieveLow(),
-      new DriveTowardsPose(1.75,true,0.3, gamePiecePose, m_drive, m_photonVision),
+      new DriveTowardsPose(Units.inchesToMeters(69.0), 0.3, gamePiecePose, m_drive, m_photonVision),
 
       //stow the arm
       new ArmStow(),
 
       // return to the charge station and balance
-      new DriveTowardsPose(1.75, false, 0.5, returnBalancePose, m_drive, m_photonVision),
-      new DriveToDistance(-1, m_drive),
+      new DriveTowardsPose(Units.inchesToMeters(-69.0), 0.5, returnBalancePose, m_drive, m_photonVision),
+      new DriveToDistance(Units.inchesToMeters(-40), m_drive),
       new AutoBalancePID(m_drive),
 
       new PrintCommand(getName() + " Finished")

--- a/src/main/java/frc/robot/commands/auto/RB_2_Exit_Balance_Vision.java
+++ b/src/main/java/frc/robot/commands/auto/RB_2_Exit_Balance_Vision.java
@@ -47,13 +47,11 @@ public class RB_2_Exit_Balance_Vision extends SequentialCommandGroup {
       ),
 
       // Drive over the charge station and exit the community
-      new DriveToDistanceVision(3.94, false, 0.3, m_drive, m_photonVision),
+      new DriveToDistanceVision(Units.inchesToMeters(-155), 0.3, m_drive, m_photonVision),
       new TurnToAngle(180, m_drive),
-      new DriveToDistance(-1.3, m_drive),
+      new DriveToDistance(Units.inchesToMeters(-51), m_drive),
       // Balance on the charge station
       new AutoBalancePID(m_drive),
-      
-      
 
       new PrintCommand(getName() + " Finished")
     );

--- a/src/main/java/frc/robot/commands/driver/AutoArmRetrieveMedium.java
+++ b/src/main/java/frc/robot/commands/driver/AutoArmRetrieveMedium.java
@@ -20,9 +20,10 @@ public class AutoArmRetrieveMedium extends SequentialCommandGroup {
     addCommands(
       new ArmToSetpoint(ArmConstants.AutoMode.SHELF),
       new TelescopeToSetpoint(ArmConstants.AutoMode.SHELF),
-      new ClawRetrieve(),
-      new ClawWaitOnPiece(),
-      new ClawHold());
+      new ClawRetrieve()
+      // Same changes as AutoArmRetrieveLow
+      // new ClawWaitOnPiece(),
+      // new ClawHold()
+    );
   }
-
 }


### PR DESCRIPTION
Change signature of 2 new vision commands to remove redundance (only need meters, not direction)
Use units of inches for consistency with other commands