### PR TITLE
Remove fwd filtering at low velocity

### DIFF
--- a/src/main/java/frc/constants/DriveConstants.java
+++ b/src/main/java/frc/constants/DriveConstants.java
@@ -53,4 +53,7 @@ public class DriveConstants {
     public static final double kRotationBoostLow      = 0.40;
     public static final double kRotationBoostHigh     = 1.0;
 
+    // Ignore filtering of forward input at low speed
+    public static final double kMinVelocityForFilter  = 0.2;
+
 }

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -153,6 +153,10 @@ public class DriveSubsystem extends SubsystemBase {
       DriveConstants.kRotationBoostLow, DriveConstants.kRotationBoostHigh);
     
     double f_fwd = speedFilter.calculate(fwd);
+    // Ignore filtering of input at low speeds
+    // if (Math.abs(velocity) < DriveConstants.kMinVelocityForFilter) {
+    //   f_fwd = fwd;
+    // }
     double f_rot = rotationFilter.calculate(rot * rotBoost * rotDeadzone);
     m_drive.arcadeDrive(f_fwd, f_rot, squaredInput);
   }


### PR DESCRIPTION
Tweak added as a comment. 
Just as we modify low-velocity behavior for rotation, do the same for forward velocity.
Needs testing.